### PR TITLE
Updated Header Bar (Fixes #2)

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -127,10 +127,16 @@ public class Marquer.MainWindow : Hdy.ApplicationWindow {
         grid_main.attach(left_grid, 0, 0, 1, 1);
         grid_main.attach(right_grid, 1, 0, 3, 1);
         
-        var header_bar = new Hdy.WindowHandle();
-        header_bar.add(grid_main);
+        var hdy_header = new Hdy.HeaderBar ();
+        hdy_header.title = "Marquer";
+        hdy_header.show_close_button = true;
+        hdy_header.decoration_layout = "close:";
         
-        add(header_bar);
+        var hdy_grid = new Gtk.Grid ();
+        hdy_grid.attach (hdy_header, 0, 0);
+        hdy_grid.attach (grid_main, 0, 1);
+        
+        add(hdy_grid);
         show_all();
     }
     

--- a/src/Widgets/RightSelectDisk.vala
+++ b/src/Widgets/RightSelectDisk.vala
@@ -21,7 +21,7 @@
 public class Marquer.Widgets.RightSelectDisk : Gtk.Grid {
     private Granite.Widgets.WelcomeButton select_optic_file;
     private Granite.Widgets.WelcomeButton download_optic_file;    
-    private Granite.Widgets.WelcomeButton close_app;
+    //ISSUE #2 private Granite.Widgets.WelcomeButton close_app;
     private Marquer.Utils.VolatileDataStore volatile_data_store;
     public signal void user_selection_completed ();
         
@@ -45,15 +45,15 @@ public class Marquer.Widgets.RightSelectDisk : Gtk.Grid {
         var download_file_icon = new Gtk.Image();
         download_file_icon.gicon = new ThemedIcon("emblem-downloads");
         
-        var close_app_icon = new Gtk.Image();
-        close_app_icon.gicon = new ThemedIcon("process-stop"); 
+        //ISSUE #2 var close_app_icon = new Gtk.Image();
+        //ISSUE #2 close_app_icon.gicon = new ThemedIcon("process-stop"); 
         
         select_optic_file = new Granite.Widgets.WelcomeButton (browse_file_icon, "Open Disk Image", "Choose an Existing Disk Image");
         download_optic_file = new Granite.Widgets.WelcomeButton (download_file_icon, "Download Disk Image", "Download a Disk Image from the Internet");        
-        close_app = new Granite.Widgets.WelcomeButton (close_app_icon, "Close", "Close the Application");
+        //ISSUE #2 close_app = new Granite.Widgets.WelcomeButton (close_app_icon, "Close", "Close the Application");
         
         select_optic_file.clicked.connect (browse_optic_file);
-        close_app.clicked.connect (close_application);        
+        //ISSUE #2 close_app.clicked.connect (close_application);        
         
         this.vexpand = true;
         this.hexpand = true;
@@ -64,7 +64,7 @@ public class Marquer.Widgets.RightSelectDisk : Gtk.Grid {
         //Attach Elements to Grid
         attach (select_optic_file, 0, 0);
         attach (download_optic_file, 0, 1);
-        attach (close_app, 0, 2);
+        //ISSUE #2 attach (close_app, 0, 2);
     }
     
     private void close_application () {


### PR DESCRIPTION
Fixes #2 
---------
Redesigned the close application option. Added the close button to a newly created header bar instead of the old Option as a `Granite.WelcomeButton` in Carousel Page 1

![Screenshot from 2021-06-15 07 50 46](https://user-images.githubusercontent.com/47198395/121983516-10d07580-cdaf-11eb-9fd5-d488a24303a7.png)
