### PR TITLE
Implemented Carousel Line Indicators, Redesign

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -109,7 +109,7 @@ public class Marquer.MainWindow : Hdy.ApplicationWindow {
             }
         });                
         
-        var carousel_indicator = new Hdy.CarouselIndicatorDots ();
+        var carousel_indicator = new Hdy.CarouselIndicatorLines ();
         carousel_indicator.set_carousel(right_carousel);
         
         left_grid = new Gtk.Grid ();


### PR DESCRIPTION
Fixes #3 
------------------
A carousel was used instead of the traditional Etcher Like UI to help users navigate better and also to **explicitly indicate there are only three steps in the process**.

Taking @hanaral's suggestion, I've used `CarouselIndicatorLines` replacing the previously `CarouselIndicatorDots`. 
![Screenshot from 2021-06-15 08 03 55](https://user-images.githubusercontent.com/47198395/121984659-fdbea500-cdb0-11eb-820e-8c10bfc5aeae.png)
